### PR TITLE
Fix: LinkedIn incorrect user schema and undefined profile data response

### DIFF
--- a/packages/backend/config/passport.js
+++ b/packages/backend/config/passport.js
@@ -80,7 +80,6 @@ exports.linkedinStrategy = new LinkedInStrategy(
     clientSecret: process.env.LINKEDIN_clientSecret,
     callbackURL: "/auth/linkedin/callback",
     scope: ["r_emailaddress", "r_liteprofile"],
-    passReqToCallback: true,
   },
   async (accessToken, refreshToken, profile, cb) => {
     console.log(chalk.blue(JSON.stringify(profile)));
@@ -88,8 +87,8 @@ exports.linkedinStrategy = new LinkedInStrategy(
     const newUser = {
       googleId: profile.id,
       displayName: profile.displayName,
-      email: profile.emails,
-      photo: profile.photo,
+      email: profile.emails[0].value,
+      photo: profile.photos[1].value || profile.photos[0].value ,
       provider: "linkedin"
     }
 


### PR DESCRIPTION
Errors - 

- Undefined profile data response in Linkedin OAuth strategy.
- Incorrect parsing schema for LinkedIn OAuth data.

Fix -

- Remove ` passReqToCallback: true ` parameter in LinkedIn Strategy.
- Change user schema for parsing the LinkedIn profile data.