### PR TITLE
feat: add community api route with pagination support

### DIFF
--- a/packages/backend/api/community/controller.js
+++ b/packages/backend/api/community/controller.js
@@ -1,0 +1,35 @@
+const Community = require('./model');
+const asyncHandler = require('../../middleware/async');
+const moongosePaginate =  require('mongoose-paginate-v2');
+
+//const Community = db.community;
+
+const getPagination = (page, size) => {
+    const limit = size  ? + size : 3;
+    const offset = page ? page*limit : 0;
+
+    return { limit, offset };
+};
+
+const getAllCommunity = asyncHandler(async (req, res) => {
+    const { page, size } = req.query;
+    const { limit, offset } = getPagination(page, size);
+
+    Community.paginate( {}, {offset, limit})
+        .then((data) => {
+            res.send({
+                data: data
+            });
+        })
+        .catch((err) => {
+            res.sendStatus(500).send({
+                message:
+                    err.message || "Some error occured while retrieving communities."
+            });
+        });
+
+});
+
+module.exports = {
+    getAllCommunity
+}

--- a/packages/backend/api/community/index.js
+++ b/packages/backend/api/community/index.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+const communityController = require('./controller.js')
+
+//router.get("/:id", communityController.getEvent);
+router.get("/all*", communityController.getAllCommunity);
+//router.get("/:id", communityController.getEvent);
+//router.get("/:id", communityController.getEvent);
+
+module.exports = router;
+

--- a/packages/backend/api/community/model.js
+++ b/packages/backend/api/community/model.js
@@ -1,0 +1,23 @@
+const mongoose = require('mongoose');
+const mongoosePaginate = require('mongoose-paginate-v2');
+
+const communitySchema = new mongoose.Schema({
+        
+    org_id: { type: Object, required: true },
+    name: { type: String, required: true },
+    description: { type: String, required: true },
+    region: { type: String, required: true },
+    size: { type: Number, required: true },
+    email: { type: String, required: true },
+    website: { type: String, required: true },
+    logo: { type: String, required: true },
+    community_type: { type: String, required: true },
+    stack_involved: { type: Array, required: true },
+    members: { type: Array },
+    speakers: { type: Array },
+    
+});
+
+communitySchema.plugin(mongoosePaginate)
+
+module.exports = mongoose.model('communities', communitySchema);

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -31,6 +31,7 @@
     "http-errors": "~1.6.3",
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^5.11.13",
+    "mongoose-paginate-v2": "^1.4.2",
     "nodemon": "^2.0.12",
     "passport": "^0.4.1",
     "passport-github": "^1.1.0",

--- a/packages/backend/server.js
+++ b/packages/backend/server.js
@@ -23,6 +23,8 @@ require("colors");
 
 // route files
 const auth = require("./api/auth/index");
+const community = require("./api/community/index");
+
 const app = express();
 // Body Parser
 
@@ -68,6 +70,7 @@ app.use(express.static(path.join(__dirname, "../frontend", "build")))
 
 // Use Routes
 app.use('/api/auth', auth);
+app.use('/api/community', community);
 
 app.get("*", (req, res) => {
     res.sendFile(path.join(__dirname, "../frontend", "build", "index.html"));

--- a/yarn.lock
+++ b/yarn.lock
@@ -10185,6 +10185,11 @@ mongoose-legacy-pluralize@1.0.2:
   resolved "https://registry.yarnpkg.com/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz#3ba9f91fa507b5186d399fb40854bff18fb563e4"
   integrity sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==
 
+mongoose-paginate-v2@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/mongoose-paginate-v2/-/mongoose-paginate-v2-1.4.2.tgz#482cea73f4a0bd49131ef9004694c73cae93b73e"
+  integrity sha512-b7FBe7fasJazhlTIfMSPyIST04yvobASXKmUt3ducnvYThulCyGSPhPcSYOzXcPmqBR4tpMnafIJxv+8GjM+UA==
+
 mongoose@^5.11.13:
   version "5.13.9"
   resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-5.13.9.tgz#4421a13566daea8fcc80149734c76e5641f477ce"


### PR DESCRIPTION
New API route for retrieving all community/organization. 

> /api/community/all

Endpoint parameters - 

``` 
1. Page - Page number(Positive) to fetch
2. Size - Number of entities to fetch in a single page 
```